### PR TITLE
dont use browser alias for component-event dep

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-import ev from 'event';
+import ev from 'component-event';
 import contains from 'node-contains';
 
 /**

--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
     "component-event": "0.1.4",
     "node-contains": "1.0.0"
   },
-  "browser": {
-    "event": "component-event"
-  },
   "devDependencies": {
     "babel": "4.7.4"
   }


### PR DESCRIPTION
@denis-sokolov I forked this project because I need to implement the "click outside" on some fields in the dashboard. Now this module rename for the browser confuses node who knows nothing about an `event` module.
